### PR TITLE
Additions to CLI tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib-cov
 *.out
 *.pid
 *.gz
+*.swp
 
 pids
 logs

--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ saved into a config at: `~/.config/gitify.js` for future runs
 
     gitify [<repo> <description> <user> <password>]
 
+If the information provided is not complete, a CLI pop up will appear, prompting for the valid information.
+
+For example,
+
+    gitify aaa bbb ccc
+
+will prompt
+
+    ? Please input your repository name:  (aaa)
+    ? Please input your repository description:  (bbb)
+    ? Please input your username:  (ccc)
+    ? Please input your password: 
+
+where the input parameters are set as default values (meaning pressing `[Enter]` is the same as inputting that string)
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ gitify(
 saved into a config at: `~/.config/gitify.js` for future runs 
 
 ## Commandline
+To use the Commandline tool, install it globally with
+
+    npm install -g gitify
+
+Then run with
 
     gitify [<repo> <description> <user> <password>]
 

--- a/bin/gitify.js
+++ b/bin/gitify.js
@@ -1,25 +1,41 @@
 #!/usr/bin/env node
+var prompt = require("./prompt.js");
 
-var gitify = require('..')
-  , argv = process.argv;
+var gitify = require('..'), 
+    argv = process.argv;
 
-var repo        =  argv[2]
-  , description =  argv[3]
-  , user        =  argv[4]
-  , password    =  argv[5];
-  
-gitify(
-    { user        :  user
-    , password    :  password
-    , repo        :  repo
-    , description :  description
-    }
-  , function (err) {
-      if (err) { 
+var repo        =  argv[2], 
+    description =  argv[3], 
+    user        =  argv[4], 
+    password    =  argv[5];
+
+var gitifyObj = { 
+    user        :  user,
+    password    :  password, 
+    repo        :  repo, 
+    description :  description
+}, 
+gitifyCallback = function (err) {
+    if (err) { 
         console.error(err);
         if (err.err && err.err.errors) console.error(err.err.errors);
         return;
-      }
-      console.log('The current directory was successfully gitified.');
     }
-);
+    console.log('The current directory was successfully gitified.');
+};
+
+if (argv.length < 6) {
+    prompt.forInformation(repo, description, user, password, function(result){
+        gitifyObj = { 
+            user        :  result.user, 
+            password    :  result.password, 
+            repo        :  result.repo, 
+            description :  result.description
+        };
+        gitify(gitifyObj, gitifyCallback);
+    });
+}
+else {
+    gitify(gitifyObj, gitifyCallback);
+}
+

--- a/bin/prompt.js
+++ b/bin/prompt.js
@@ -1,0 +1,38 @@
+"use strict";
+var inq = require("inquirer");
+
+var validateEmptyValue = function(value){
+    return (value) ? true : "Please input a non-empty entry";
+}
+
+var forInformation = function(repo, description, user, password, callback){
+    var questions = [{
+        type: "input",
+        message: "Please input your repository name: ",
+        name: "repo",
+        default: repo,
+        validate: validateEmptyValue
+    }, {
+        type: "input",
+        message: "Please input your repository description: ",
+        name: "description",
+        default: description
+    }, {
+        type: "input",
+        message: "Please input your username: ",
+        name: "user",
+        default: user
+    }, {
+        type: "password",
+        message: "Please input your password: ",
+        name: "password"
+    }];
+
+    inq.prompt(questions, function(result){
+        callback(result);
+    });
+};
+
+module.exports = {
+    forInformation: forInformation
+}

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
   },
   "homepage": "https://github.com/thlorenz/gitify",
   "dependencies": {
-    "request": "~2.21.0",
-    "runnel": "~0.3.2",
+    "configurate": "~0.1.1",
+    "inquirer": "^0.10.0",
     "promfig": "~0.1.0",
-    "configurate": "~0.1.1"
+    "request": "~2.21.0",
+    "runnel": "~0.3.2"
   },
   "devDependencies": {
     "nave": "~0.4.3",


### PR DESCRIPTION
I added more to the CLI part of gitify, so questions will appear during incomplete information. This means that running `gitify` itself will prompt for repo-name, description, username, and password. The CLI previously showed the password on commandline, which I thought was insecure (especially for people peering over shoulders), and this addition will mask the password during prompt.
